### PR TITLE
TravisCI: Test on PHP 7.2 and nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,16 @@ cache:
 
 matrix:
   include:
+    - php: nightly
+    - php: 7.2
     - php: 7.1
     - php: 7.0
     - php: 5.6
       env: WP_TRAVISCI=phpcs
     - php: 5.3
       dist: precise
+  allow_failures:
+    - php: nightly
 
 services:
     - redis-server


### PR DESCRIPTION
Please read the test logs on travis. There are some errors and warnings (which exist in [current master](https://github.com/humanmade/wp-redis-predis-client/tree/351a02bf831b453a42411d16be931bf637a910b6)).