### PR TITLE
Allow redis server to enable persistent connections

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -83,6 +83,7 @@ function build_options( $args ) {
 		'parameters' => array(
 			'password' => isset( $args['auth'] ) ? $args['auth'] : null,
 			'database' => isset( $args['database'] ) ? $args['database'] : null,
+			'persistent' => isset( $args['persistent'] ) ? $args['persistent'] : null,
 		),
 	);
 


### PR DESCRIPTION
Predis support persistent connections which will drammatically improve connection times. See https://github.com/nrk/predis/wiki/Connection-Parameters. In my testing, a Redis connection with TLS that is external to the local server takes around 50 milliseconds to initiate. Persistent connections will be shared for the FPM worker process, so we can expect to have a pretty good hit rate on those connections.

Also, under multisite, WordPress does _two_ `wp_cache_init` calls, which causes 2 connects, slowing things down further without this enabled.