### PR TITLE
Disconnect the Redis socket on fatal shutdown

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -11,6 +11,7 @@ function add_filters( $add_filter_fn = 'add_filter' ) {
 	$add_filter_fn( 'wp_redis_prepare_client_connection_callback', 'WP_Predis\prepare_client_connection_callback' );
 	$add_filter_fn( 'wp_redis_perform_client_connection_callback', 'WP_Predis\perform_client_connection_callback', 10, 3 );
 	$add_filter_fn( 'wp_redis_retry_exception_messages', 'WP_Predis\append_error_messages' );
+	$add_filter_fn( 'shutdown', 'WP_Predis\shutdown', 10, 0 );
 }
 
 function check_client_dependencies() {
@@ -106,4 +107,23 @@ function prepare_client_connection_callback() {
 
 function perform_client_connection_callback() {
 	return 'WP_Predis\perform_client_connection';
+}
+
+/**
+ * Shutdown hook.
+ *
+ * Runs during shutdown, even if the shutdown happened due
+ * to a fatal error/exception.
+ */
+function shutdown() {
+	global $wp_object_cache;
+
+	// Disconnect a Redis socket if the shutdown happened with a fatal.
+	// Prevents a persistent socket from being corrupted if the error
+	// happens while reading from Redis.
+
+	$error = error_get_last();
+	if ( $error && $error['type'] === E_ERROR && isset( $wp_object_cache->redis ) ) {
+		$wp_object_cache->redis->disconnect();
+	}
 }


### PR DESCRIPTION
A fatal error during socket read/write (such as a memory exhausted error) can result in a corrupted persistent socket for future PHP requests. This change explicitly disconnects the Redis socket on shutdown that happened with a fatal error.

The problem can be reproduced by enabling persistent connections, writing a large value to Redis:

```
$buffer = '';
for ( $i = 0; $i <= 1024 * 1024 * 32; $i++ ) {
	$buffer .= chr( rand( 65, 90 ) );
}
wp_cache_set( 'foo', $buffer );
```

Then attempting to read that value with a low enough memory limit:

```
ini_set( 'memory_limit', '4M' );
wp_cache_get_multiple( [ 'foo', 'bar', 'baz' ] );
```

This should cause a memory exhausted fatal error in predis/src/Connection/StreamConnection.php exiting the script but leaving the persistent socket in a connected state, which in subsequent requests leads to poisoning/corruption.