### PR TITLE
Log when wp_cache_flush() is called

### DIFF
--- a/class-wp-predis-decorator.php
+++ b/class-wp-predis-decorator.php
@@ -57,13 +57,7 @@ class Decorator {
 	public function __call( $method_name, $args ) {
 		// Optionally prevent flushing on non-cli.
 		if ( in_array( strtolower( $method_name ), [ 'flushdb', 'flushall' ], true ) ) {
-			if ( function_exists( 'wp_debug_backtrace_summary' ) ) {
-				$trace = wp_debug_backtrace_summary();
-			} else {
-				$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 );
-				$caller    = array_shift( $backtrace );
-				$trace =  $caller['file'] . ':' . $caller['line'];
-			}
+			$trace = wp_debug_backtrace_summary();
 			error_log( sprintf( 'wp_cache_flush() requested from ' . $trace ) );
 
 			if ( 'cli' !== php_sapi_name() ) {

--- a/class-wp-predis-decorator.php
+++ b/class-wp-predis-decorator.php
@@ -60,7 +60,12 @@ class Decorator {
 			$trace = wp_debug_backtrace_summary();
 			error_log( sprintf( 'wp_cache_flush() requested from ' . $trace ) );
 
-			$allowed = apply_filters( 'wp_cache_flush_allowed_non_cli', 'cli' === php_sapi_name() );
+			/**
+			 * Filter whether to allow flushing. By default, only allowed on the CLI.
+			 *
+			 * @param bool True to permit flushing, false to disallow it and return immediately.
+			 */
+			$allowed = apply_filters( 'wp_cache_flush_allowed', 'cli' === php_sapi_name() );
 			if ( ! $allowed ) {
 				trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called from %s', $trace ), E_USER_WARNING );
 				return false;


### PR DESCRIPTION
Also, add a filter to disallow flushing on non-cli. The default may be changed in the future.

The two error logs:


`wp_cache_flush() requested from require_once('wp-load.php'), require_once('/usr/src/app/wp-config.php'), require_once('wp-settings.php'), do_action('init'), WP_Hook->do_action, WP_Hook->apply_filters, {closure}, wp_cache_flush, WP_Object_Cache->flush, WP_Object_Cache->_call_redis, WP_Predis\Decorator->__call
dev-php `

`PHP Warning:  wp_cache_flush() is only allowed via WP CLI. Called from require_once('wp-load.php'), require_once('/usr/src/app/wp-config.php'), require_once('wp-settings.php'), do_action('init'), WP_Hook->do_action, WP_Hook->apply_filters, {closure}, wp_cache_flush, WP_Object_Cache->flush, WP_Object_Cache->_call_redis, WP_Predis\Decorator->__call in /usr/src/app/extra-packages/wp-redis-predis-client/class-wp-predis-decorator.php on line 72`