### PR TITLE
Register shutdown handler directly

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -11,7 +11,6 @@ function add_filters( $add_filter_fn = 'add_filter' ) {
 	$add_filter_fn( 'wp_redis_prepare_client_connection_callback', 'WP_Predis\prepare_client_connection_callback' );
 	$add_filter_fn( 'wp_redis_perform_client_connection_callback', 'WP_Predis\perform_client_connection_callback', 10, 3 );
 	$add_filter_fn( 'wp_redis_retry_exception_messages', 'WP_Predis\append_error_messages' );
-	$add_filter_fn( 'shutdown', 'WP_Predis\shutdown', 10, 0 );
 }
 
 function check_client_dependencies() {

--- a/object-cache.php
+++ b/object-cache.php
@@ -1,3 +1,8 @@
 <?php
 WP_Predis\add_filters();
+
+// Immediately register shutdown function, to ensure we catch all errors, even
+// before WP registers its own shutdown function.
+register_shutdown_function( 'WP_Predis\shutdown' );
+
 require_once dirname( __FILE__ ) . '/plugins/wp-redis/object-cache.php';


### PR DESCRIPTION
In cases where an error occurs before WP is able to register its own shutdown function, or where the shutdown function *itself* crashes (eg an OOM in X-Ray), this ensures we always clean up our socket.